### PR TITLE
Pull Request from Loyola Uni Chicago team, re: edits for energy filtration

### DIFF
--- a/simpledst-maps/src/README.txt
+++ b/simpledst-maps/src/README.txt
@@ -1,0 +1,37 @@
+INSTRUCTIONS TO PRODUCE SKYMAPS
+
+Step 0: Editing the code.
+* Edit @USER_DIR@ in scripts/make-local-maps-IT.py.in, scripts/merge-reco.py.in, and the four shell scripts in run_burnsample/*/
+to the user-appropriate directories. 
+  - fpath should be a directory containing only the burnsample root files
+  - outdir should be unique for each tier, and will contain the local and final skymaps.
+  - the cmd line should hold the location of your make-local-maps file
+
+* Edit @CVMFS_ROOTBASE@ in make-local-maps-IT.py.in and merge-reco.py.in.
+  - default='/cvmfs/icecube/opensciencegrid.org/py3-v4.2.1',
+
+* Specify which reconstruction to use in SimpleDST.cc.
+  - For Tier 1, we use ShowerPlane. So, on line XX, comment out 'reco = Laputop' and uncomment 'reco = ShowerPlane.'
+  - For Tiers 2, 3 and 4, we use Laputop. Do the inverse of the above.
+
+* Rebuild the project with the following commands. Make sure you are in Cobalt and have run CVMFS (version py3-v4.2.1)
+  - cd ~/cra-tools-gb-edits/simpledst-maps
+  - mkdir build
+  - cd build
+  - cmake ../src
+  - make
+
+To Run:
+Step 1: Producing Local Skymaps
+* SSH into the condor machine and run CVMFS (version py3-v4.2.1). 
+
+* Go into run_burnsample. For the tier you want to run, go into that directory and run the shell script. Make sure
+that the output directory is empty of any existing folders, as the code does not overwrite any existing files.
+
+Step 2: Combining Local Skymaps 
+* SSH into cobalt and run CVMFS (version py3-v4.2.1).
+
+* Go into run_bursample and into the directory for the tier you want to process.
+
+* For each tier, run the below command (edit the user directory to the output directory for each tier):
+ - python ../../scripts/merge-reco.py.in -c ITpass2 -o /data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/@USER_DIR@ --sd --reco --submit_dir ./submit

--- a/simpledst-maps/src/private/Laputop.cc
+++ b/simpledst-maps/src/private/Laputop.cc
@@ -1,0 +1,18 @@
+#include <Laputop.h>
+#include <string>
+#include <TBranch.h>
+#include <TChain.h>
+
+void
+Laputop::SetupChain(TChain* chain, std::string config)
+{
+  std::string detector = config.substr(0,2);
+
+  if (detector == "ITpass2") {
+
+    chain->SetBranchAddress("time", &time, &b_time);
+    chain->SetBranchAddress("zenith", &Zenith, &b_Zenith);
+    chain->SetBranchAddress("azimuth", &Azimuth, &b_Azimuth);
+  }
+
+}

--- a/simpledst-maps/src/private/ShowerPlane.cc
+++ b/simpledst-maps/src/private/ShowerPlane.cc
@@ -1,0 +1,18 @@
+#include <ShowerPlane.h>
+#include <string>
+#include <TBranch.h>
+#include <TChain.h>
+
+void
+ShowerPlane::SetupChain(TChain* chain, std::string config)
+{
+  std::string detector = config.substr(0,2);
+
+  if (detector == "ITpass2") {
+
+    chain->SetBranchAddress("time", &time, &b_time);
+    chain->SetBranchAddress("zenith", &Zenith, &b_Zenith);
+    chain->SetBranchAddress("azimuth", &Azimuth, &b_Azimuth);
+  }
+
+}

--- a/simpledst-maps/src/private/SimpleDST.cc
+++ b/simpledst-maps/src/private/SimpleDST.cc
@@ -34,7 +34,10 @@ SimpleDST::SetupChain(TChain* chain, std::string config)
     if (config == "IT81-2013")
       reco = "LaputopStandard";
     else if (config == "ITpass2")
-      reco = "LaputopSmall";
+      // EDIT TO CORRECT RECONSTRUCTION
+      //reco = "LaputopSmall";
+      reco = "Laputop"
+      //reco = "ShowerPlane"
 
     std::string recoazstr(reco + ".azimuth");
     std::string recozstr(reco + ".zenith");
@@ -82,7 +85,7 @@ SimpleDST::SetupChain(TChain* chain, std::string config)
     //Laputop values
     if (config == "ITpass2"){
         chain->SetBranchAddress("LaputopParams.s125", &s125, &b_s125);
-        chain->SetBranchAddress("LaputopSmallParams.s125", &ss125, &b_ss125);
+        //chain->SetBranchAddress("LaputopSmallParams.s125", &ss125, &b_ss125);
     } else {
         chain->SetBranchAddress("LaputopStandardParams.s125", &s125, &b_s125);
         chain->SetBranchAddress("LaputopSmallShowerParams.s125", &ss125, &b_ss125);

--- a/simpledst-maps/src/private/cuts.cc
+++ b/simpledst-maps/src/private/cuts.cc
@@ -140,7 +140,7 @@ bool ITNstatCut(SimpleDST dst, double smin, double smax) {
   if (!(smax > 0))
     return (dst.nStations >=smin);
     
-  return ( (dst.nStations >=smin) && (dst.nStations <=smax));
+  return ( (dst.nStations >=smin) && (dst.nStations < smax));
 
 }
 

--- a/simpledst-maps/src/private/make-local-maps.cc
+++ b/simpledst-maps/src/private/make-local-maps.cc
@@ -306,8 +306,9 @@ int main(int argc, char* argv[])
 
        // Energy cuts for IceTop and IceCube
        if (cfg.detector == Config::IceTop) {
-           if (cfg.cfg == Config::ITv3) { 
-               if (!ITNstatCut(dst, slogmin,slogmax)) 
+           if (cfg.cfg == Config::ITv3) {
+		// Energy cuts based on smin <= nStations < smax 
+               if (!ITNstatCut(dst, smin,smax)) 
                    continue;
            } else { 
                if (!ITenergyCut(dst, elogmin,elogmax)) 

--- a/simpledst-maps/src/private/make-local-maps.cc
+++ b/simpledst-maps/src/private/make-local-maps.cc
@@ -324,6 +324,10 @@ int main(int argc, char* argv[])
        
        pointing pt(zenith, azimuth);
 
+       // Check if angle above pi
+       if(pt.theta > 3.141592) 
+           continue;
+
        eventweight = 1.0;
        if (sundp) { 
            Direction dir(zenith,azimuth);

--- a/simpledst-maps/src/resources/ICETOP.json
+++ b/simpledst-maps/src/resources/ICETOP.json
@@ -5,7 +5,7 @@
       "name":"IceTop",
       "longitude":-90.0,
       "latitude":-90.0,
-      "thetamax":60.0,
+      "thetamax":90.0,
       "prefix":"/data/sim/sim-new/test/local-maps/ITpass2/combined/CR_ICECUBE_LOCAL_NSIDE64_degbin-",
       "suffix":".fits.gz"
     }

--- a/simpledst-maps/src/run_burnsample/tier1/tier1.sh
+++ b/simpledst-maps/src/run_burnsample/tier1/tier1.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+function run_makemaps {
+    year=$1
+    options=$2
+
+    # Run the command to produce the dag scripts.
+    command="python ../../scripts/make-local-maps-IT.py.in -c ITpass2 -o /data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/@USER_DIR@/tier1 --sd $options"
+    $command
+
+    # Submit the dag files for each year to condor. This will produce 360 fits files for each day in this tier.
+    commandtwo="condor_submit_dag ./submit_$year/ITpass2.make-local-maps.dag"
+    $commandtwo
+}
+
+# Define the options for each year
+declare -A options_per_year
+options_per_year[2011]="-d 20110514 20120512 -i --smin 3 --smax 5 --submit_dir ./submit_2011"
+options_per_year[2012]="-d 20120513 20130430 -i --smin 3 --smax 5 --submit_dir ./submit_2012"
+options_per_year[2013]="-d 20130501 20140506 -i --smin 3 --smax 5 --submit_dir ./submit_2013"
+options_per_year[2014]="-d 20140507 20150515 -i --smin 3 --smax 5 --submit_dir ./submit_2014"
+
+# Iterate over 10 years
+for year in {2011..2014}; do
+    options=${options_per_year[$year]}
+
+    # Run make-local-maps-IT.py.in for each year with the correct nStation boundaries.
+    run_makemaps $year "$options"
+
+done
+

--- a/simpledst-maps/src/run_burnsample/tier2/tier2.sh
+++ b/simpledst-maps/src/run_burnsample/tier2/tier2.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+function run_makemaps {
+    year=$1
+    options=$2
+
+    # Run the script to produce the dag files.
+    command="python ../scripts/make-local-maps-IT.py.in -c ITpass2 -o /data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/outputg/tier2_90bs --sd $options"
+    $command
+
+    # Submit the dag file for each year to conodr. This will create 360 fits files for each day in this tier.
+    commandtwo="condor_submit_dag ./submit_$year/ITpass2.make-local-maps.dag"
+    $commandtwo
+}
+
+# Define the options for each year
+declare -A options_per_year
+options_per_year[2011]="-d 20110514 20120512 -i --smin 5 --smax 10 --submit_dir ./submit_2011"
+options_per_year[2012]="-d 20120513 20130430 -i --smin 5 --smax 9 --submit_dir ./submit_2012"
+options_per_year[2013]="-d 20130501 20140506 -i --smin 5 --smax 9 --submit_dir ./submit_2013"
+options_per_year[2014]="-d 20140507 20150515 -i --smin 5 --smax 8 --submit_dir ./submit_2014"
+
+
+# Iterate over 10 years
+for year in {2011..2014}; do
+    options=${options_per_year[$year]}
+
+    # For each year, run make-local-maps-IT.py.in with the correct nStation boundaries.
+    run_makemaps $year "$options"
+
+done
+

--- a/simpledst-maps/src/run_burnsample/tier3/tier3.sh
+++ b/simpledst-maps/src/run_burnsample/tier3/tier3.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function run_makemaps {
+    year=$1
+    options=$2
+
+    # Run the script to produce the dag files.
+    command="python ../scripts/make-local-maps-IT.py.in -c ITpass2 -o /data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/outputg/tier3_90bs --sd $options"
+    $command
+
+    # Submit the dag file for each year to condor. This will produce 360 fits files for each day in the tier.
+    commandtwo="condor_submit_dag ./submit_$year/ITpass2.make-local-maps.dag"
+    $commandtwo
+}
+
+# Define the options for each year
+declare -A options_per_year
+options_per_year[2011]="-d 20110514 20120512 -i --smin 10 --smax 17 --submit_dir ./submit_2011"
+options_per_year[2012]="-d 20120513 20130430 -i --smin 9 --smax 16 --submit_dir ./submit_2012"
+options_per_year[2013]="-d 20130501 20140506 -i --smin 9 --smax 16 --submit_dir ./submit_2013"
+options_per_year[2014]="-d 20140507 20150515 -i --smin 8 --smax 15 --submit_dir ./submit_2014"
+options_per_year[2015]="-d 20150516 20160516 -i --smin 8 --smax 15 --submit_dir ./submit_2015"
+options_per_year[2016]="-d 20160517 20170515 -i --smin 7 --smax 14 --submit_dir ./submit_2016"
+options_per_year[2017]="-d 20170516 20180628 -i --smin 7 --smax 14 --submit_dir ./submit_2017"
+options_per_year[2018]="-d 20180629 20190630 -i --smin 6 --smax 13 --submit_dir ./submit_2018"
+options_per_year[2019]="-d 20190701 20200527 -i --smin 6 --smax 13 --submit_dir ./submit_2019"
+options_per_year[2020]="-d 20200528 20210525 -i --smin 5 --smax 12 --submit_dir ./submit_2020"
+options_per_year[2021]="-d 20210526 20220628 -i --smin 5 --smax 12 --submit_dir ./submit_2021"
+
+
+# Iterate over 10 years
+for year in {2011..2021}; do
+    options=${options_per_year[$year]}
+
+    # Run make-local-maps-IT.py.in for each year with the correct nStation boundaries.
+    run_makemaps $year "$options"
+
+done
+

--- a/simpledst-maps/src/run_burnsample/tier4/tier4.sh
+++ b/simpledst-maps/src/run_burnsample/tier4/tier4.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+function run_makemaps {
+    year=$1
+    options=$2
+
+    # Run the script to produce the dag files.
+    command="python ../scripts/make-local-maps-IT.py.in -c ITpass2 -o /data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/outputg/tier4_90bs --sd $options"
+    $command
+
+    # Submit the dag file for each year to condor. This will produce 360 fits files for each day in the tier.
+    commandtwo="condor_submit_dag ./submit_$year/ITpass2.make-local-maps.dag"
+    $commandtwo
+}
+
+# Define the options for each year
+declare -A options_per_year
+options_per_year[2011]="-d 20110514 20120512 -i --smin 17 --smax 100 --submit_dir ./submit_2011"
+options_per_year[2012]="-d 20120513 20130430 -i --smin 16 --smax 100 --submit_dir ./submit_2012"
+options_per_year[2013]="-d 20130501 20140506 -i --smin 16 --smax 100 --submit_dir ./submit_2013"
+options_per_year[2014]="-d 20140507 20150515 -i --smin 15 --smax 100 --submit_dir ./submit_2014"
+options_per_year[2015]="-d 20150516 20160516 -i --smin 15 --smax 100 --submit_dir ./submit_2015"
+options_per_year[2016]="-d 20160517 20170515 -i --smin 14 --smax 100 --submit_dir ./submit_2016"
+options_per_year[2017]="-d 20170516 20180628 -i --smin 14 --smax 100 --submit_dir ./submit_2017"
+options_per_year[2018]="-d 20180629 20190630 -i --smin 13 --smax 100 --submit_dir ./submit_2018"
+options_per_year[2019]="-d 20190701 20200527 -i --smin 13 --smax 100 --submit_dir ./submit_2019"
+options_per_year[2020]="-d 20200528 20210525 -i --smin 12 --smax 100 --submit_dir ./submit_2020"
+options_per_year[2021]="-d 20210526 20220628 -i --smin 12 --smax 100 --submit_dir ./submit_2021"
+
+
+# Iterate over 10 years
+for year in {2011..2021}; do
+    options=${options_per_year[$year]}
+
+    # Run make-local-maps-IT.py.in for each year with the correct nStation boundaries.
+    run_makemaps $year "$options"
+
+done
+

--- a/simpledst-maps/src/scripts/make-local-maps-IT.py.in
+++ b/simpledst-maps/src/scripts/make-local-maps-IT.py.in
@@ -15,7 +15,9 @@ the word 'CHANGE'.
 
 def getDSTfiles(config):
 
-    fpath = '/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2'
+    # CHANGE
+    #fpath = '/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2'
+    fpath = '/data/user/@USER_DIR@/burnsamplemaps'
     fileList = glob.glob('{}/*.root'.format(fpath))
     # Newer years have part files nested in daily folders
     if fileList == []:
@@ -59,7 +61,7 @@ if __name__ == "__main__":
 
     # Additional options
     p.add_argument('-o', '--outdir', dest='outdir',
-            # CHANGE: suggested path: /data/user/[username]/maps
+            # CHANGE: suggested path: /data/user/[username]/tier_X for each tier
             default='/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/@USER_DIR@',
             help='Destination directory for output files')
     p.add_argument('--test', dest='test',

--- a/simpledst-maps/src/scripts/make-local-maps-IT.py.in
+++ b/simpledst-maps/src/scripts/make-local-maps-IT.py.in
@@ -7,15 +7,15 @@ import random
 #sys.path.append('/home/fmcnally/npx4')
 from npx4.pysubmit import pysubmit
 
-""" 
-INSTRUCTIONS: before executing, change hardcoded paths anywhere you see 
+"""
+INSTRUCTIONS: before executing, change hardcoded paths anywhere you see
 the word 'CHANGE'.
 """
 
 
 def getDSTfiles(config):
 
-    fpath = '/data/user/gbratrud/dst_data'
+    fpath = '/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2'
     fileList = glob.glob('{}/*.root'.format(fpath))
     # Newer years have part files nested in daily folders
     if fileList == []:
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     # Additional options
     p.add_argument('-o', '--outdir', dest='outdir',
             # CHANGE: suggested path: /data/user/[username]/maps
-            default='@CRA_BUILD@/maps',
+            default='/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/@USER_DIR@',
             help='Destination directory for output files')
     p.add_argument('--test', dest='test',
             default=False, action='store_true',
@@ -73,29 +73,32 @@ if __name__ == "__main__":
             help='Path to spline files')
     p.add_argument('--cvmfs', dest='cvmfs',
             default='@CVMFS_SROOTBASE@',
-            help='CVMFS environment')
+            help='CVMFS environment, should be py3-v4.2.1 at least')
     p.add_argument('--submit_dir', dest='submit_dir',
-            default='@CRA_BUILD@/submit-dir',
+            default='/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/src/submit',
             help='submit directory')
     p.add_argument('--smax', dest='smax',
             default=0.0,
-            help='max STA8')
+            help='max nStations, noninclusive')
     p.add_argument('--smin', dest='smin',
             default=0.0,
-            help='min STA8')
+            help='min nStations, inclusive')
     p.add_argument('--nside', dest='nsideout',
             default=64,
             help='Healpix NSide parameter')
     p.add_argument('--condor-priority', dest='priority',
-            default=1, 
+            default=1,
             help='Job priority in condor')
+    p.add_argument('--method', dest='method',
+            default=None,
+            help='Method for time - ext (extended sidereal), anti (antisidereal), solar (solar)')
     ### USER-SPECIFIC PATHS (CHANGE) ###
     """ These paths all refer to directories. Make sure you create your
     own directories as needed """
     # Submitter capable of submitting multiple days as one job, w/
     # TimeScramble.cc reading filelist from .txt file.
-    #  - determines .txt file location (can remove after jobs run) 
-    
+    #  - determines .txt file location (can remove after jobs run)
+
 
     args = p.parse_args()
     c_opts = vars(args).copy()
@@ -178,7 +181,7 @@ if __name__ == "__main__":
 
     # Set up parameters to feed C++ script
     print('Parameters for submission:')
-    validArgs  = ['config','smax','smin','nsideout']
+    validArgs  = ['config','smax','smin','nsideout', 'method']
     c_opts = {k:v for k,v in c_opts.items() if v!=None and k in validArgs}
     for key in sorted(c_opts.keys()):
         print('  --%s %s' % (key, c_opts[key]))
@@ -213,7 +216,7 @@ if __name__ == "__main__":
     for i in range(len(dayFiles)):
 
         jobID = 'makelocalmaps_%s_%05i_%05i' % (args.config, i, random.randint(0,99999))
-        cmd  = '@CRA_BUILD@/bin/make-local-maps' 
+        cmd  = '/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/build/bin/make-local-maps' 
         subdir = dateList[i].strftime('%Y-%m-%d')
         ex = [cmd, c_opts,'--outdir','{}/{}'.format(outBase,subdir), '--input', dayFiles[i] ]
         ex = ' '.join(ex)

--- a/simpledst-maps/src/scripts/merge-reco.py.in
+++ b/simpledst-maps/src/scripts/merge-reco.py.in
@@ -8,8 +8,8 @@ import subprocess
 #sys.path.append('/home/fmcnally/npx4')
 from npx4.pysubmit import pysubmit
 
-""" 
-INSTRUCTIONS: before executing, change hardcoded paths anywhere you see 
+"""
+INSTRUCTIONS: before executing, change hardcoded paths anywhere you see
 the word 'CHANGE'.
 """
 
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
     # Additional options
     p.add_argument('-o', '--outdir', dest='outdir',
-            default='@CRA_BUILD@/maps',
+            default='/data/ana/CosmicRay/Anisotropy/IceTop/ITpass2/output/@USER_DIR@/ITpass2_sd',
             help='Destination directory for output files')
     p.add_argument('-i', '--indir', dest='indir',
             default=None,
@@ -71,9 +71,9 @@ if __name__ == "__main__":
             help='Option to overwrite existing map files')
     p.add_argument('--cvmfs', dest='cvmfs',
             default='@CVMFS_SROOTBASE@',
-            help='CVMFS environment')
+            help='CVMFS environment, should be py3-v4.2.1 at least')
     p.add_argument('--submit_dir', dest='submit_dir',
-            default='@CRA_BUILD@/submit-dir',
+            default='/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/src/submit',
             help='submit directory')
     p.add_argument('--elogmax', dest='elogmax',type=float,
             default=0.0,
@@ -83,10 +83,10 @@ if __name__ == "__main__":
             help='min log energy/GeV')
     p.add_argument('--smax', dest='smax',type=int,
             default=0,
-            help='max nStations')
+            help='max nStations, noninclusive')
     p.add_argument('--smin', dest='smin',type=int,
             default=0,
-            help='min nStations')
+            help='min nStations, inclusive')
     p.add_argument('--ndirc_min', dest='ndirc_min',
             default=9,
             help='min ndir value')
@@ -104,13 +104,13 @@ if __name__ == "__main__":
     own directories as needed """
     # Submitter capable of submitting multiple days as one job, w/
     # TimeScramble.cc reading filelist from .txt file.
-    #  - determines .txt file location (can remove after jobs run) 
+    #  - determines .txt file location (can remove after jobs run)
 
     args = p.parse_args()
 
     if args.indir is None:
         args.indir = args.outdir
-    
+
     c_opts = vars(args).copy()
     s_opts = vars(args).copy()
     if not args.config:
@@ -168,9 +168,9 @@ if __name__ == "__main__":
     if not os.path.isdir('{}/combined'.format(outBase)):
         os.makedirs('{}/combined'.format(outBase))
 
-    s_opts['detector'] = "ICECUBE" 
+    s_opts['detector'] = "ICECUBE"
     if args.config.startswith("IT"):
-        s_opts['detector'] = "ICETOP" 
+        s_opts['detector'] = "ICETOP"
 
     shexec=''
     s_opts["erange"] = ""
@@ -187,7 +187,7 @@ if __name__ == "__main__":
     for degbin in range(0,360):
 
         # Filter by desired dates
-        if args.dates is None: 
+        if args.dates is None:
             print(os.path.join(inBase,"*",infile).format(**s_opts,degbin=degbin))
             filelist = glob.glob(os.path.join(inBase,"*",infile).format(**s_opts,degbin=degbin))
             if not filelist:
@@ -205,11 +205,11 @@ if __name__ == "__main__":
                     os._exit(1)
                 else:
                     print("warning:", "file",f,"does not exist!")
-                    
+
 
         outfile = infile.format(**s_opts,degbin=degbin)
         jobID = 'combinelocalmaps_%s_%05i_%05i' % (args.config, degbin, random.randint(0,99999))
-        cmd  = '@CRA_BUILD@/bin/combine-local-maps' 
+        cmd  = '/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/build/bin/combine-local-maps'
         #ex = [cmd] + c_opts + ['--outfile','{}/combined/{}'.format(outBase,outfile), '--input', " ".join(filelist) ]
         ex = [cmd] + c_opts + ['--outfile','{}/combined/{}'.format(outBase,outfile), '--input'] +filelist
         #ex = [cmd, c_opts,'--outfile','{}/combined/{}'.format(outBase,outfile), '--input', " ".join(filelist) ]
@@ -221,10 +221,10 @@ if __name__ == "__main__":
     if args.reco:
 
         reco_prefix = infile_prefix.format(**s_opts)
-        cmd  = '@CRA_BUILD@/bin/illh-reco'
-        ex  = [cmd, 
-            '--cfg','@CRA_BUILD@/resources/{detector}.json'.format(**s_opts),
-            '--prefix','{}/combined/{}'.format(outBase,reco_prefix), 
+        cmd  = '/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/build/bin/illh-reco'
+        ex  = [cmd,
+            '--cfg','/home/@USER_DIR@/cra-tools-gb-edits/simpledst-maps/build/resources/{detector}.json'.format(**s_opts),
+            '--prefix','{}/combined/{}'.format(outBase,reco_prefix),
             '--suffix','.fits.gz',
             '--outdir','{}/reco'.format(outBase),
             ]
@@ -239,4 +239,3 @@ if __name__ == "__main__":
                 )
     else:
        print(shexec)
-     

--- a/simpledst-maps/src/scripts/merge-reco.py.in
+++ b/simpledst-maps/src/scripts/merge-reco.py.in
@@ -181,6 +181,8 @@ if __name__ == "__main__":
 
     if args.smax > 0:
         s_opts["srange"] = "_{smin:d}-{smax:d}S".format(**s_opts)
+    else:
+        s_opts["srange"] = "*"
     infile_prefix = "CR_{detector}_LOCAL{erange}{srange}_NSIDE{nsideout}_degbin-"
     infile = infile_prefix+"{degbin:03d}.fits.gz"
 


### PR DESCRIPTION
We've made minor edits:
- cuts.cc that turns the ITN energy cut filtration method to **noninclusive** on the higher end
- make-local-maps.cc that changes the parameters passed to the ITN energy filtration method to be no. of stations
- added argument in the make-local-maps-IT python file that allows us to change the time method (sidereal, anti, etc.)
- added description of the smin and smax parameters in the python files
- change in notation in python files in how we refer to the user-specific paths for certain directories (e.g. submit, output, etc.).